### PR TITLE
Add radius and volume to CoreShell

### DIFF
--- a/PyMieSim/single/scatterer/core_shell.py
+++ b/PyMieSim/single/scatterer/core_shell.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import numpy
 import pyvista
 from PyOptik.material.base_class import BaseMaterial
 
@@ -35,7 +36,7 @@ class CoreShell(CORESHELL, BaseScatterer):
     source: BaseSource
 
     property_names = [
-        "size_parameter", "cross_section", "g",
+        "size_parameter", "radius", "volume", "cross_section", "g",
         "Qsca", "Qext", "Qabs", "Qback", "Qratio", "Qpr",
         "Csca", "Cext", "Cabs", "Cback", "Cratio", "Cpr"
     ]
@@ -84,6 +85,17 @@ class CoreShell(CORESHELL, BaseScatterer):
             medium_refractive_index=self.medium_index.to(units.RIU).magnitude,
             source=self.source
         )
+
+    @property
+    def radius(self) -> units.Quantity:
+        """Return the outer radius of the scatterer."""
+        return self.core_diameter / 2 + self.shell_thickness
+
+    @property
+    def volume(self) -> units.Quantity:
+        """Return the volume of the scatterer."""
+        vol = (4/3) * numpy.pi * (self.radius ** 3)
+        return vol.to(units.meter ** 3)
 
     def _add_to_3d_ax(self, scene: pyvista.Plotter, color: str = 'black', opacity: float = 1.0) -> None:
         """

--- a/tests/single/scatterers/test_coreshell.py
+++ b/tests/single/scatterers/test_coreshell.py
@@ -17,7 +17,7 @@ shell_property = [Material.BK7, Material.iron, 1.7 * RIU]
 medium_property = [Material.water, 1.4 * RIU]
 
 attributes = [
-    "size_parameter", "cross_section", "g", "Qsca", "Qext", "Qabs", "Qback", "Qratio", "an", "bn",
+    "size_parameter", "radius", "volume", "cross_section", "g", "Qsca", "Qext", "Qabs", "Qback", "Qratio", "an", "bn",
     "Qforward", "Qpr", "Csca", "Cext", "Cabs", "Cback", "Cratio", "Cforward", "Cpr"
 ]
 


### PR DESCRIPTION
## Summary
- extend CoreShell scatterer with `radius` and `volume` properties
- update tests to cover new attributes

## Testing
- `pytest tests/single/scatterers/test_coreshell.py::test_attribute -q`

------
https://chatgpt.com/codex/tasks/task_e_687a93401dd4832c86465add4190fe9d