### PR TITLE
Add array-based scattering calculations

### DIFF
--- a/PyMieSim/single/scatterer/base.py
+++ b/PyMieSim/single/scatterer/base.py
@@ -126,6 +126,86 @@ class BaseScatterer(units.UnitsValidation):
         """
         return self._cpp_get_fields(phi=phi, theta=theta, r=r.to_base_units().magnitude)
 
+    def get_s1s2_array(self, phi: numpy.ndarray) -> Tuple[numpy.ndarray, numpy.ndarray]:
+        """Return the S1 and S2 scattering amplitudes for arbitrary ``phi`` angles.
+
+        Parameters
+        ----------
+        phi : numpy.ndarray
+            Array of azimuthal angles in **radians** for which the scattering
+            amplitudes are computed.
+
+        Returns
+        -------
+        Tuple[numpy.ndarray, numpy.ndarray]
+            Arrays of ``S1`` and ``S2`` values evaluated at the supplied angles.
+        """
+
+        phi = numpy.atleast_1d(phi)
+        return self._cpp_get_s1s2(phi=phi + numpy.pi / 2)
+
+    def get_stokes_array(
+        self,
+        phi: numpy.ndarray,
+        theta: numpy.ndarray,
+        r: units.Quantity = 1 * units.meter
+    ) -> Tuple[numpy.ndarray, numpy.ndarray, numpy.ndarray, numpy.ndarray]:
+        """Return the Stokes parameters for arbitrary ``phi`` and ``theta`` angles.
+
+        Parameters
+        ----------
+        phi : numpy.ndarray
+            Azimuthal angles in radians.
+        theta : numpy.ndarray
+            Polar angles in radians. Must be broadcastable with ``phi``.
+        r : units.Quantity, optional
+            Radial distance from the scatterer. Defaults to ``1 * meter``.
+
+        Returns
+        -------
+        Tuple[numpy.ndarray, numpy.ndarray, numpy.ndarray, numpy.ndarray]
+            The ``I``, ``Q``, ``U`` and ``V`` Stokes parameters.
+        """
+
+        phi, theta = numpy.broadcast_arrays(phi, theta)
+
+        E_phi, E_theta = self.get_farfields_array(phi=phi, theta=theta, r=r)
+
+        intensity = numpy.abs(E_phi) ** 2 + numpy.abs(E_theta) ** 2
+        I = intensity / numpy.max(intensity)
+        Q = (numpy.abs(E_phi) ** 2 - numpy.abs(E_theta) ** 2) / intensity
+        U = (+2 * numpy.real(E_phi * E_theta.conjugate())) / intensity
+        V = (-2 * numpy.imag(E_phi * E_theta.conjugate())) / intensity
+
+        return I, Q, U, V
+
+    def get_far_field_array(
+        self,
+        phi: numpy.ndarray,
+        theta: numpy.ndarray,
+        r: units.Quantity = 1 * units.meter
+    ) -> Tuple[numpy.ndarray, numpy.ndarray]:
+        """Return the far-field electric fields for arbitrary ``phi`` and ``theta``.
+
+        Parameters
+        ----------
+        phi : numpy.ndarray
+            Azimuthal angles in radians.
+        theta : numpy.ndarray
+            Polar angles in radians. Must be broadcastable with ``phi``.
+        r : units.Quantity, optional
+            Radial distance from the scatterer. Defaults to ``1 * meter``.
+
+        Returns
+        -------
+        Tuple[numpy.ndarray, numpy.ndarray]
+            Complex ``E_phi`` and ``E_theta`` field components.
+        """
+
+        phi, theta = numpy.broadcast_arrays(phi, theta)
+        E_phi, E_theta = self.get_farfields_array(phi=phi, theta=theta, r=r)
+        return E_phi, E_theta
+
     def get_s1s2(self, sampling: int = 200, distance: units.Quantity = 1 * units.meter) -> S1S2:
         r"""
         Compute the S1 and S2 scattering amplitude functions for a spherical scatterer.

--- a/docs/examples/extras/README.rst
+++ b/docs/examples/extras/README.rst
@@ -12,3 +12,4 @@ Contents
 - ``plot_coupling_heatmap.py`` – visualise coupling as a function of NA and refractive index.
 - ``plot_system.py`` – draw the arrangement of sources, detectors and scatterers.
 - ``plot_Qsca_vs_permittivity_vs_size_parameter.py`` – inspect scattering as material and size vary.
+- ``array_scattering.py`` – compute fields and Stokes parameters for arbitrary angles.

--- a/docs/examples/extras/array_scattering.py
+++ b/docs/examples/extras/array_scattering.py
@@ -1,0 +1,48 @@
+"""
+Array-based scattering calculations
+===================================
+
+This example demonstrates how to compute far fields, S1/S2 amplitudes and
+Stokes parameters using arbitrary ``phi`` and ``theta`` arrays.
+"""
+
+import numpy as np
+from PyMieSim.single.scatterer import Sphere
+from PyMieSim.single.source import PlaneWave
+from PyMieSim.units import nanometer, degree, watt, RIU
+
+# %%
+# Create a simple plane wave source
+source = PlaneWave(
+    wavelength=632.8 * nanometer,
+    polarization=0 * degree,
+    optical_power=1 * watt,
+)
+
+# %%
+# Define the scatterer
+scatterer = Sphere(
+    diameter=200 * nanometer,
+    property=1.5 * RIU,
+    medium_property=1.0 * RIU,
+    source=source,
+)
+
+# Define arbitrary angle arrays
+phi = np.linspace(0, np.pi, 8)
+theta = np.linspace(0, np.pi / 2, 8)
+
+# %%
+# Far-field complex fields
+E_para, E_perp = scatterer.get_far_field_array(phi, theta)
+print(E_para.shape, E_perp.shape)
+
+# %%
+# S1 and S2 scattering amplitudes
+S1, S2 = scatterer.get_s1s2_array(phi)
+print(S1.shape, S2.shape)
+
+# %%
+# Stokes parameters
+I, Q, U, V = scatterer.get_stokes_array(phi, theta)
+print(I.shape, Q.shape, U.shape, V.shape)

--- a/tests/single/scatterers/test_sphere.py
+++ b/tests/single/scatterers/test_sphere.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import pytest
+import numpy
 from PyMieSim.single.scatterer import Sphere
 from PyMieSim.single.source import Gaussian
 from PyMieSim.single.detector import Photodiode
@@ -86,6 +87,33 @@ def test_sphere_plottings(mock_show_plt, mock_show_pyvista, plotting_function, p
     assert data is not None, "Plotting data should not be None"
 
     plt.close()
+
+
+@pytest.mark.parametrize('property', property, ids=[f'property:{m}' for m in property])
+@pytest.mark.parametrize('medium_property', medium_property, ids=[f'Medium:{m}' for m in medium_property])
+def test_unstructured_array_functions(property, medium_property, source):
+    scatterer = Sphere(
+        diameter=100 * nanometer,
+        source=source,
+        medium_property=medium_property,
+        property=property
+    )
+
+    phi = numpy.linspace(0, numpy.pi, 5)
+    s1, s2 = scatterer.get_s1s2_array(phi)
+    assert s1.shape == phi.shape
+    assert s2.shape == phi.shape
+
+    theta = numpy.linspace(0, numpy.pi / 2, 5)
+    I, Q, U, V = scatterer.get_stokes_array(phi, theta)
+    assert I.shape == phi.shape
+    assert Q.shape == phi.shape
+    assert U.shape == phi.shape
+    assert V.shape == phi.shape
+
+    E_para, E_perp = scatterer.get_far_field_array(phi, theta)
+    assert E_para.shape == phi.shape
+    assert E_perp.shape == phi.shape
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support unstructured angles via `get_far_field_array` in scatterer base
- include new example `array_scattering.py` demonstrating all array helpers
- test far field array routine alongside S1S2 and Stokes
- return complex fields instead of intensities from `get_far_field_array`

## Testing
- `pytest tests/single/scatterers/test_sphere.py::test_unstructured_array_functions -q` *(fails: ModuleNotFoundError: No module named 'PyMieSim.binary.interface_scatterer')*

------
https://chatgpt.com/codex/tasks/task_e_687c14155690832c9cda6c19a1453da6