### PR TITLE
fix error with pyinstaller not importing representations

### DIFF
--- a/PyMieSim/single/__init__.py
+++ b/PyMieSim/single/__init__.py
@@ -5,5 +5,6 @@ import PyMieSim.mesh as _mesh  # noqa: F401, W292
 import PyMieSim.coordinates as _coordinates  # noqa: F401, W292
 import PyMieSim.material as _material  # noqa: F401, W292
 import PyMieSim.single.setup as _setup  # noqa: F401, W292
+import PyMieSim.single.representations as _representations  # noqa: F401, W292
 
 Setup = _setup.Setup


### PR DESCRIPTION
Hi Martin, 
when tryign to get RosettaX into 1 executable using pyinstaller it would not complete because it couldnt load representations. 
After adding the one line for representations, pyinstaller does work. 

Stack Trace: 
550826 INFO: Looking for dynamic libraries
C:\Users\P100700\AppData\Local\Programs\Python\Python312\Lib\site-packages\PyInstaller\building\build_main.py:227: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  __import__(package)
Traceback (most recent call last):
  File "C:\Users\P100700\AppData\Local\Programs\Python\Python312\Lib\site-packages\PyInstaller\building\build_main.py", line 287, in find_binary_dependencies
    child.call(import_library, package)
  File "C:\Users\P100700\AppData\Local\Programs\Python\Python312\Lib\site-packages\PyInstaller\isolated\_parent.py", line 322, in call
    raise SubprocessDiedError(
PyInstaller.isolated._parent.SubprocessDiedError: Child process died calling import_library() with args=('PyMieSim.single.representations',) and kwargs={}. Its exit code was 3221225477.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\P100700\AppData\Local\Programs\Python\Python312\Scripts\pyinstaller.exe\__main__.py", line 5, in <module>
  File "C:\Users\P100700\AppData\Local\Programs\Python\Python312\Lib\site-packages\PyInstaller\__main__.py", line 231, in _console_script_run
    run()
  File "C:\Users\P100700\AppData\Local\Programs\Python\Python312\Lib\site-packages\PyInstaller\__main__.py", line 215, in run
    run_build(pyi_config, spec_file, **vars(args))
  File "C:\Users\P100700\AppData\Local\Programs\Python\Python312\Lib\site-packages\PyInstaller\__main__.py", line 70, in run_build
    PyInstaller.building.build_main.main(pyi_config, spec_file, **kwargs)
  File "C:\Users\P100700\AppData\Local\Programs\Python\Python312\Lib\site-packages\PyInstaller\building\build_main.py", line 1275, in main
    build(specfile, distpath, workpath, clean_build)
  File "C:\Users\P100700\AppData\Local\Programs\Python\Python312\Lib\site-packages\PyInstaller\building\build_main.py", line 1213, in build
    exec(code, spec_namespace)
  File "main.spec", line 25, in <module>
    a = Analysis(
        ^^^^^^^^^
  File "C:\Users\P100700\AppData\Local\Programs\Python\Python312\Lib\site-packages\PyInstaller\building\build_main.py", line 584, in __init__
    self.__postinit__()
  File "C:\Users\P100700\AppData\Local\Programs\Python\Python312\Lib\site-packages\PyInstaller\building\datastruct.py", line 184, in __postinit__
    self.assemble()
  File "C:\Users\P100700\AppData\Local\Programs\Python\Python312\Lib\site-packages\PyInstaller\building\build_main.py", line 967, in assemble
    find_binary_dependencies(self.binaries, collected_packages, self.graph._bindepend_symlink_suppression)
  File "C:\Users\P100700\AppData\Local\Programs\Python\Python312\Lib\site-packages\PyInstaller\building\build_main.py", line 291, in find_binary_dependencies
    raise isolated.SubprocessDiedError(
PyInstaller.isolated._parent.SubprocessDiedError: Isolated subprocess crashed while importing package 'PyMieSim.single.representations'! Package import list: ... 